### PR TITLE
feat: note warnings on offense report

### DIFF
--- a/ASSEMBLY_bot_files/_botClass.py
+++ b/ASSEMBLY_bot_files/_botClass.py
@@ -221,6 +221,15 @@ class AssemblyBot(BotHelpers, BotCommands, BotEvents):
                 color=discord.Color.yellow()
             )
 
+            # Check if the user has any warnings and note it on the report
+            record = self._pull_records(str(user)) or {}
+            warning_count = len(record.get("warnings", []))
+            if warning_count > 0:
+                user_embed.description += (
+                    f"\n\n__**Note:**__ This user has {warning_count} warning"
+                    f"{'s' if warning_count != 1 else ''} on record."
+                )
+
             # If there are more than 25 offenses, notify the user to manually view them
             if len(offenses) > 25: # 25 is the max number of fields a Discord embed can have
                 user_embed.description += (


### PR DESCRIPTION
## Summary
- warn moderators when reported users also have warnings on record
- only show warning note when warning count is greater than zero

## Testing
- `python -m py_compile ASSEMBLY_bot_files/_botClass.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78e166d4c832794f570ec2a715e75